### PR TITLE
Update chain_plugin.cpp

### DIFF
--- a/libraries/plugins/chain/chain_plugin.cpp
+++ b/libraries/plugins/chain/chain_plugin.cpp
@@ -323,10 +323,10 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("sps-remove-threshold", bpo::value<uint16_t>()->default_value( 200 ), "Maximum numbers of proposals/votes which can be removed in the same cycle")
          ("shared-file-dir", bpo::value<bfs::path>()->default_value("blockchain"),
             "the location of the chain shared memory files (absolute path or relative to application data dir)")
-         ("shared-file-size", bpo::value<string>()->default_value("54G"), "Size of the shared memory file. Default: 54G. If running a full node, increase this value to 200G.")
-         ("shared-file-full-threshold", bpo::value<uint16_t>()->default_value(0),
+         ("shared-file-size", bpo::value<string>()->default_value("64G"), "Size of the shared memory file. Default: 64G. If running a full node, increase this value to 200G.")
+         ("shared-file-full-threshold", bpo::value<uint16_t>()->default_value(9500),
             "A 2 precision percentage (0-10000) that defines the threshold for when to autoscale the shared memory file. Setting this to 0 disables autoscaling. Recommended value for consensus node is 9500 (95%). Full node is 9900 (99%)" )
-         ("shared-file-scale-rate", bpo::value<uint16_t>()->default_value(0),
+         ("shared-file-scale-rate", bpo::value<uint16_t>()->default_value(1000),
             "A 2 precision percentage (0-10000) that defines how quickly to scale the shared memory file. When autoscaling occurs the file's size will be increased by this percent. Setting this to 0 disables autoscaling. Recommended value is between 1000-2000 (10-20%)" )
          ("checkpoint,c", bpo::value<vector<string>>()->composing(), "Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.")
          ("flush-state-interval", bpo::value<uint32_t>(),


### PR DESCRIPTION
default config now has `shared-file-size` set to `64G` and enabled auto scaling (95% full, 10% rate)