### PR TITLE
Update the inflation data

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The technical development of the Hive blockchain itself is carried out by the fo
 * Currency symbol HIVE
 * HBD - Hive's very own stable coin with a one-way peg
 * Delegated Proof-of-Stake Consensus (DPoS)
-* 10% APR inflation narrowing to 1% APR over 20 years
+* 7% APR inflation (as of 2021) narrowing to 1% APR over 20 years
     * 65% of inflation to authors/curators.
     * 15% of inflation to stakeholders.
     * 10% of inflation to block producers.


### PR DESCRIPTION
The inflation is way off, by a margin of 30%, (from 10% on readme to less than 7% currently) which is huge!

Needs to add to the readme the year in which the measurement was taken, also when does the inflation ends, if it is left "20 years" it can be misleading, will it be 20 years forever?....

## Inflation calculation

* Right now every block generates a HP reward of 0.25HP to the producer
    * 10% of inflation to block producers, so total inflation is 2.5HP per block
    * targeting 1 block every 3 seconds 
    * 2.5HP * 20 blocks per minute * 525,960 minutes per year = 26,298,000HP in 1 year
    * Current supply is 381,457,172 Hive (Hive only) or 411,066,161 (Hive + HBD)
    * 525,960 is 6.9% out of Hive only supply, or 6.4% out of Hive + HBD
    * 30% margin of difference. Must be updated

## TODO:
* Update the "narrowing to 1% APR over 20 years"
* If the inflation is off by over 30%, how wrong is the 20 years, and in which year, precisely, does it end?

## Goal:
* More precise information, so end users can estimate by themselves using simple math